### PR TITLE
fix csproj error

### DIFF
--- a/MicrosoftGraphAspNetCoreConnectSample/MicrosoftGraphAspNetCoreConnectSample.csproj
+++ b/MicrosoftGraphAspNetCoreConnectSample/MicrosoftGraphAspNetCoreConnectSample.csproj
@@ -12,11 +12,7 @@
     <UserSecretsId>aspnet-MicrosoftGraphAspNetCoreConnectSample-ec1d62b9-d84d-45c8-8b3e-dc4e8b2ed850</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="wwwroot\email_template.html" />
-    <Content Include="wwwroot\images\blank-profile-picture.svg" />
-  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.2" />
@@ -32,6 +28,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
+  
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.1" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.1" />


### PR DESCRIPTION
Currently, the project does not build because some items are included as Content:

> C:\Program Files\dotnet\sdk\2.0.0\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.DefaultItems.targets 286,5): error : Duplicate 'Content' items were included. The .NET SDK includes 'Content' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultContentItems' property to 'false' if you want to explicitly include them in your project file. For more information, see https://aka.ms/sdkimplicititems. The duplicate items were: 'wwwroot\email_template.html'; 'wwwroot\images\blank-profile-picture.svg'

This change simply fix this.