### PR TITLE
Fix uncaught exception when sending email

### DIFF
--- a/MicrosoftGraphAspNetCoreConnectSample/Helpers/GraphService.cs
+++ b/MicrosoftGraphAspNetCoreConnectSample/Helpers/GraphService.cs
@@ -194,18 +194,21 @@ namespace MicrosoftGraphAspNetCoreConnectSample.Helpers
                 // Load user's profile picture.
                 var pictureStream = await GetMyPictureStream(graphClient, httpContext);
 
-                // Copy stream to MemoryStream object so that it can be converted to byte array.
-                var pictureMemoryStream = new MemoryStream();
-                await pictureStream.CopyToAsync(pictureMemoryStream);
-
-                // Convert stream to byte array and add as attachment.
-                attachments.Add(new FileAttachment
+                if (pictureStream != null)
                 {
-                    ODataType = "#microsoft.graph.fileAttachment",
-                    ContentBytes = pictureMemoryStream.ToArray(),
-                    ContentType = "image/png",
-                    Name = "me.png"
-                });
+                    // Copy stream to MemoryStream object so that it can be converted to byte array.
+                    var pictureMemoryStream = new MemoryStream();
+                    await pictureStream.CopyToAsync(pictureMemoryStream);
+
+                    // Convert stream to byte array and add as attachment.
+                    attachments.Add(new FileAttachment
+                    {
+                        ODataType = "#microsoft.graph.fileAttachment",
+                        ContentBytes = pictureMemoryStream.ToArray(),
+                        ContentType = "image/png",
+                        Name = "me.png"
+                    });
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Only attempt to attach the user's profile picture if they actually have
one.

If the user does not have a profile picture `pictureMemoryStream` is
null and the code throws an exception when attempting to add it as an
attachment.

Rewrote in my free time to avoid CLA issues. This PR supersedes https://github.com/microsoftgraph/aspnetcore-connect-sample/pull/52